### PR TITLE
remove broken interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ jobs:
           app: example
 ```
 
+You will need to set the `CONVOX_PASSWORD` environment variable on your project to your Convox deploy key.
+
 ## See Also
 
 https://circleci.com/orbs/registry/orb/convox/orb

--- a/orb.yml
+++ b/orb.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 description: |
   Deploy applications to Convox
+  You must set your Convox deploy key as a project environment variable CONVOX_PASSWORD
 
 display:
   home_url: https://convox.com
@@ -52,10 +53,6 @@ executors:
 commands:
   deploy:
     parameters:
-      deploy-key:
-        description: Deploy Key - https://docs.convox.com/console/deploy-keys
-        type: string
-        default: "$CONVOX_DEPLOY_KEY"
       app:
         description: Application Name
         type: string
@@ -73,7 +70,6 @@ commands:
       - run:
           name: Deploy Application
           environment:
-            CONVOX_PASSWORD: << parameters.deploy-key >>
             CONVOX_HOST: << parameters.host >>
             CONVOX_RACK: << parameters.rack >>
           command: convox deploy --app << parameters.app >>
@@ -81,10 +77,6 @@ commands:
 jobs:
   deploy:
     parameters:
-      deploy-key:
-        description: Deploy Key - https://docs.convox.com/console/deploy-keys
-        type: string
-        default: "$CONVOX_DEPLOY_KEY"
       app:
         description: Application Name
         type: string
@@ -101,7 +93,6 @@ jobs:
     steps:
       - checkout
       - deploy:
-          deploy-key: << parameters.deploy-key >>
           app: << parameters.app >>
           rack: << parameters.rack >>
           host: << parameters.host >>


### PR DESCRIPTION
Seems that CircleCI no longer allows for environment variable interpolation when setting environment values.